### PR TITLE
add Error Visibility Timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id AWS_SECRET_ACCESS_KEY=your-secr
 |`SQSD_QUEUE_URL`||yes|The URL of the SQS queue.|
 |`SQSD_QUEUE_MAX_MSGS`|`10`|no|Max number of messages a worker should try to receive from the SQS queue.|
 |`SQSD_QUEUE_WAIT_TIME`|`10`|no|The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. Setting this to `0` disables long polling. Maximum of `20` seconds.|
+|`SQSD_ERROR_VISIBILITY_TIMEOUT`|`none`|no|The duration seconds before message is visible again after an unsuccessful operation with an explicit error.|
 |`SQSD_HTTP_MAX_CONNS`|`25`|no|Maximum number of concurrent HTTP requests to make to SQSD_HTTP_URL.|
 |`SQSD_HTTP_URL`||yes|The URL of your service to make a request to.|
 |`SQSD_HTTP_CONTENT_TYPE` ||no|The value to send for the HTTP header `Content-Type` when making a request to your service.|

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -17,10 +17,11 @@ import (
 )
 
 type config struct {
-	QueueRegion      string
-	QueueURL         string
-	QueueMaxMessages int
-	QueueWaitTime    int
+	QueueRegion                 string
+	QueueURL                    string
+	QueueMaxMessages            int
+	QueueWaitTime               int
+	QueueErrorVisibilityTimeout int
 
 	HTTPMaxConns    int
 	HTTPURL         string
@@ -48,6 +49,7 @@ func main() {
 	c.QueueURL = os.Getenv("SQSD_QUEUE_URL")
 	c.QueueMaxMessages = getEnvInt("SQSD_QUEUE_MAX_MSGS", 10)
 	c.QueueWaitTime = getEnvInt("SQSD_QUEUE_WAIT_TIME", 10)
+	c.QueueErrorVisibilityTimeout = getEnvInt("SQSD_ERROR_VISIBILITY_TIMEOUT", -1)
 
 	c.HTTPMaxConns = getEnvInt("SQSD_HTTP_MAX_CONNS", 25)
 	c.HTTPURL = os.Getenv("SQSD_HTTP_URL")
@@ -140,9 +142,10 @@ func main() {
 	sqsSvc := sqs.New(awsSess, sqsConfig)
 
 	wConf := supervisor.WorkerConfig{
-		QueueURL:         c.QueueURL,
-		QueueMaxMessages: c.QueueMaxMessages,
-		QueueWaitTime:    c.QueueWaitTime,
+		QueueURL:                    c.QueueURL,
+		QueueMaxMessages:            c.QueueMaxMessages,
+		QueueWaitTime:               c.QueueWaitTime,
+		QueueErrorVisibilityTimeout: c.QueueErrorVisibilityTimeout,
 
 		HTTPURL:         c.HTTPURL,
 		HTTPContentType: c.HTTPContentType,


### PR DESCRIPTION
Change visibility timeout if backend server return error code (ex. 4xx, 5xx).
When the value is not set, use the default value set in Amazon SQS.