### PR TITLE
primary-secondary

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id AWS_SECRET_ACCESS_KEY=your-secr
 |**Environment Variable**|**Default Value**|**Required**|**Description**|
 |-|-|-|-|
 |`SQSD_QUEUE_REGION`||yes|The region of the SQS queue.|
-|`SQSD_QUEUE_URL`||yes|The URL of the SQS queue.|
+|`SQSD_QUEUE_URL`||yes|The URL of the SQS queue.(primary)|
+|`SQSD_SECONDARY_QUEUE_URL`||no|The URL of the secondary SQS queue.|
 |`SQSD_QUEUE_MAX_MSGS`|`10`|no|Max number of messages a worker should try to receive from the SQS queue.|
 |`SQSD_QUEUE_WAIT_TIME`|`10`|no|The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. Setting this to `0` disables long polling. Maximum of `20` seconds.|
 |`SQSD_ERROR_VISIBILITY_TIMEOUT`|`none`|no|The duration seconds before message is visible again after an unsuccessful operation with an explicit error.|

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -19,6 +19,7 @@ import (
 type config struct {
 	QueueRegion                 string
 	QueueURL                    string
+	QueueSecondaryURL           string
 	QueueMaxMessages            int
 	QueueWaitTime               int
 	QueueErrorVisibilityTimeout int
@@ -47,6 +48,7 @@ func main() {
 
 	c.QueueRegion = os.Getenv("SQSD_QUEUE_REGION")
 	c.QueueURL = os.Getenv("SQSD_QUEUE_URL")
+	c.QueueSecondaryURL = os.Getenv("SQSD_SECONDARY_QUEUE_URL")
 	c.QueueMaxMessages = getEnvInt("SQSD_QUEUE_MAX_MSGS", 10)
 	c.QueueWaitTime = getEnvInt("SQSD_QUEUE_WAIT_TIME", 10)
 	c.QueueErrorVisibilityTimeout = getEnvInt("SQSD_ERROR_VISIBILITY_TIMEOUT", -1)
@@ -93,10 +95,11 @@ func main() {
 	}
 
 	logger := log.WithFields(log.Fields{
-		"queueRegion":  c.QueueRegion,
-		"queueUrl":     c.QueueURL,
-		"httpMaxConns": c.HTTPMaxConns,
-		"httpPath":     c.HTTPURL,
+		"queueRegion":       c.QueueRegion,
+		"queueUrl":          c.QueueURL,
+		"secondaryQueueUrl": c.QueueSecondaryURL,
+		"httpMaxConns":      c.HTTPMaxConns,
+		"httpPath":          c.HTTPURL,
 	})
 
 	if len(c.HTTPHealthPath) != 0 {
@@ -143,6 +146,7 @@ func main() {
 
 	wConf := supervisor.WorkerConfig{
 		QueueURL:                    c.QueueURL,
+		QueueSecondaryURL:           c.QueueSecondaryURL,
 		QueueMaxMessages:            c.QueueMaxMessages,
 		QueueWaitTime:               c.QueueWaitTime,
 		QueueErrorVisibilityTimeout: c.QueueErrorVisibilityTimeout,

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/buildsville/simple-sqsd/supervisor"
+	"github.com/showcase-gig-platform/simple-sqsd/supervisor"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -172,7 +172,10 @@ func main() {
 
 	s := supervisor.NewSupervisor(logger, sqsSvc, httpClient, wConf)
 	s.Start(c.HTTPMaxConns)
-	s.Wait()
+
+	s.WaitSignal()
+	s.Shutdown()
+	s.WaitWorker()
 }
 
 func getEnvInt(key string, def int) int {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/buildsville/simple-sqsd
+module github.com/showcase-gig-platform/simple-sqsd
 
 go 1.12
 


### PR DESCRIPTION
優先度の低いSQSを環境変数 `SQSD_SECONDARY_QUEUE_URL` で設定できるように
既存の `SQSD_QUEUE_URL` を `SQSD_PRIMARY_QUEUE_URL` などとしなかったのは後方互換性を保つため

simple-sqsdのworkerプロセスは最初に `SQSD_QUEUE_URL` からmessageを取得する
messageがあればそのまま処理に入り、終了すると再び `SQSD_QUEUE_URL` からmessageを取得する
messageがなかった場合は `SQSD_SECONDARY_QUEUE_URL` からmessageを取得して処理に入り、終了すると `SQSD_QUEUE_URL` からmessageを取得する

ここまで書いて優先度低いmessageの処理に長い時間かかるとタイミングによっては全てのプロセスが埋ってしまう事態もあり得ることに気がついた😇 
しばらく優先度高いqueueが空の状態が続いて、優先度低い処理でちょうどプロセス埋まった瞬間に優先度高いqueueにmessageが入る、みたいな
どれか空けば当然優先度高いほうが処理に入るんだけども…